### PR TITLE
Add an option to use a custom title.

### DIFF
--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -6,7 +6,7 @@
 <x-dashboard-tile :position="$position">
     <div class="grid gap-2 justify-items-center h-full text-center">
         <div class="font-medium text-dimmed text-sm uppercase tracking-wide tabular-nums">
-            {{ str_replace('_', ' ', $timezone) }}
+            {{ $title ?? str_replace('_', ' ', $timezone) }}
         </div>
         <div id="{{ $time }}" class="self-center font-bold text-4xl tracking-wide leading-none">
             {{ Carbon\Carbon::now($timezone)->format('H:i:s') }}

--- a/src/DateTimeTileComponent.php
+++ b/src/DateTimeTileComponent.php
@@ -10,11 +10,15 @@ class DateTimeTileComponent extends Component
 
     public $timezone;
 
-    public function mount(string $position, ?string $timezone)
+    public $title;
+
+    public function mount(string $position, ?string $timezone, ?string $title)
     {
         $this->position = $position;
 
         $this->timezone = $timezone ?? config('app.timezone');
+
+        $this->title = $title ?? null;
     }
 
     public function render()


### PR DESCRIPTION
This PR adds an option to display a custom string instead of the timezone, e.g.

`<livewire:date-time-tile position="a1" timezone="Europe/London" title="Greenwich Mean Time" />`